### PR TITLE
chore: add .editorconfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Add `.editorconfig` to enforce consistent coding style across all editors and IDEs.

### Changes
- Add `.editorconfig` with standard settings:
  - 2-space indentation
  - UTF-8 charset
  - LF line endings
  - Trim trailing whitespace
  - Insert final newline
  - Preserve trailing whitespace in Markdown

### Why
EditorConfig ensures consistent formatting regardless of which editor or IDE contributors use. This prevents formatting-related diffs and reduces noise in code reviews.

### Checklist
- [x] No breaking changes
- [x] File follows EditorConfig standard conventions