### PR TITLE
feat: add GET /health endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -31,6 +31,10 @@ app.register(fastifyCookies)
 
 app.register(swaggerPlugin)
 
+app.get('/health', async () => {
+  return { status: 'ok', timestamp: new Date().toISOString() }
+})
+
 app.register(usersRoutes)
 app.register(gymsRoutes)
 app.register(checkInsRoutes)


### PR DESCRIPTION
## Summary

Adds a `GET /health` endpoint to the Fastify app that returns:

```json
{ "status": "ok", "timestamp": "<ISO 8601>" }
```

- Route is registered **after** swaggerPlugin and **before** user routes.
- Useful for uptime monitoring, load balancer health checks, and k8s probes.

## Changes

- `src/app.ts`: added `app.get('/health', ...)` route