### PR TITLE
fix: Dockerfile node 22 build + node 20 runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20-slim AS base
+FROM node:22-slim AS base
 WORKDIR /app
 
 FROM base AS deps
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --production=false
+RUN yarn install --frozen-lockfile --production=false --ignore-engines
 
 FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
@@ -11,7 +11,7 @@ COPY . .
 RUN npx prisma generate
 RUN yarn build
 
-FROM base AS runner
+FROM node:20-slim AS runner
 ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=builder /app/build ./build


### PR DESCRIPTION
Build with node 22 for orval compatibility (--ignore-engines for fast-jwt), run with node 20 for fast-jwt compat.